### PR TITLE
Enable setting cookie options via attribute

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,3 +7,8 @@ exceptions = [{ allow = ["ISC", "MIT", "OpenSSL"], name = "ring" }]
 name = "ring"
 expression = "ISC AND MIT AND OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[advisories]
+# time 0.1 is a transitive dependency of chrono,
+# and the vulnerable parts aren't used in chrono.
+ignore = ["RUSTSEC-2020-0071"]

--- a/mendes-macros/src/lib.rs
+++ b/mendes-macros/src/lib.rs
@@ -11,9 +11,10 @@ mod route;
 mod util;
 
 #[proc_macro_attribute]
-pub fn cookie(_: TokenStream, item: TokenStream) -> TokenStream {
+pub fn cookie(meta: TokenStream, item: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(item as syn::ItemStruct);
-    let cookie = cookies::cookie(&ast);
+    let meta = parse_macro_input!(meta as cookies::CookieMeta);
+    let cookie = cookies::cookie(&meta, &ast);
     let mut tokens = ast.to_token_stream();
     tokens.extend(cookie);
     TokenStream::from(tokens)


### PR DESCRIPTION
This additionally changes the default to `SameSite=None; Secure`.
We now use `Max-Age` instead of `Expires`, since this requires
less work during encoding.

cc @rempelj @nrempel