### PR TITLE
Always set the cookie path (again)

### DIFF
--- a/mendes-macros/Cargo.toml
+++ b/mendes-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mendes-macros"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 description = "Macros for mendes web toolkit"
 documentation = "https://docs.rs/mendes-macros"

--- a/mendes/Cargo.toml
+++ b/mendes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mendes"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 description = "Rust web toolkit for impatient perfectionists"
 documentation = "https://docs.rs/mendes"
@@ -43,7 +43,7 @@ http = { version = "0.2", optional = true }
 http-body = { version = "0.4", optional = true }
 httparse = { version = "1.3.4", optional = true }
 hyper = { version = "0.14.1", optional = true, features = ["http1", "http2", "runtime", "server", "stream"] }
-mendes-macros = { version = "0.1", path = "../mendes-macros", optional = true }
+mendes-macros = { version = "0.1.1", path = "../mendes-macros", optional = true }
 mime_guess = { version = "2.0.3", default-features = false, optional = true }
 percent-encoding = { version = "2.1.0", default-features = false, optional = true }
 pin-utils = { version = "0.1.0", optional = true }


### PR DESCRIPTION
In #59 I removed the default `Path` set for cookies in order to more closely match the standard's behavior. However, @rempelj noticed that this broke our site, after which it turned out the default behavior for an empty path is pretty crap. Revert to always setting a `Path`, and defaulting it to `/` (as before #59).

cc @nrempel