### PR TITLE
Add check for content-length before allocating buffers

### DIFF
--- a/mendes/Cargo.toml
+++ b/mendes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mendes"
-version = "0.1.3"
+version = "0.1.4"
 description = "Rust web toolkit for impatient perfectionists"
 documentation = "https://docs.rs/mendes"
 repository = "https://github.com/djc/mendes"


### PR DESCRIPTION
Currently, the `to_bytes` function prevents a remote to send too much data. But the functions allocate a buffer if the request contains more than a chunk. A size hint is used to allocate with capacity, but the size hint takes the remote controlled `Content-Length` header into account.

We use `to_bytes` in to places, which now are guarded by a check for the upper size hint. This avoids reading any chunk if the `Content-Length` header suggests the request is larger than the library user allows.