### PR TITLE
Add Server::serve_with_graceful_shutdown

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,16 +12,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta, 1.58.0]
+        rust: [stable, beta, 1.60.0]
         exclude:
           - os: macos-latest
             rust: beta
           - os: windows-latest
             rust: beta
           - os: macos-latest
-            rust: 1.58.0
+            rust: 1.60.0
           - os: windows-latest
-            rust: 1.58.0
+            rust: 1.60.0
 
     runs-on: ${{ matrix.os }}
 

--- a/mendes-macros/Cargo.toml
+++ b/mendes-macros/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/djc/mendes"
 license = "MIT OR Apache-2.0"
 workspace = ".."
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 
 [lib]
 proc-macro = true

--- a/mendes/Cargo.toml
+++ b/mendes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mendes"
-version = "0.2.1"
+version = "0.3.0"
 description = "Rust web toolkit for impatient perfectionists"
 documentation = "https://docs.rs/mendes"
 repository = "https://github.com/djc/mendes"

--- a/mendes/Cargo.toml
+++ b/mendes/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["web", "http", "server", "async"]
 categories = ["asynchronous", "web-programming::http-server"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 workspace = ".."
 readme = "../README.md"
 

--- a/mendes/src/application.rs
+++ b/mendes/src/application.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 #[cfg(feature = "with-http-body")]
 use std::error::Error as StdError;
+use std::future::Future;
 use std::net::SocketAddr;
 use std::str;
 use std::str::FromStr;
@@ -692,4 +693,9 @@ pub trait Server: Application {
     type ServerError;
 
     async fn serve(self, addr: &SocketAddr) -> Result<(), Self::ServerError>;
+    async fn serve_with_graceful_shutdown(
+        self,
+        addr: &SocketAddr,
+        signal: impl Future<Output = ()> + Send,
+    ) -> Result<(), Self::ServerError>;
 }

--- a/mendes/src/hyper.rs
+++ b/mendes/src/hyper.rs
@@ -31,6 +31,17 @@ where
             .serve(ApplicationService::new(self))
             .await
     }
+
+    async fn serve_with_graceful_shutdown(
+        self,
+        addr: &SocketAddr,
+        signal: impl Future<Output = ()> + Send,
+    ) -> Result<(), hyper::Error> {
+        hyper::Server::bind(addr)
+            .serve(ApplicationService::new(self))
+            .with_graceful_shutdown(signal)
+            .await
+    }
 }
 
 struct ApplicationService<A>(Arc<A>);


### PR DESCRIPTION
# Description

Exposes [hyper::Server::with_graceful_shutdown](https://docs.rs/hyper/latest/hyper/server/struct.Server.html#method.with_graceful_shutdown) indirectly by adding `mendes::Server::serve_with_graceful_shutdown`. 

This approach is taken since `hyper::Server` is used internally and not returned by `mendes::Server::serve`.

### Breaking changes

- Add `Server::serve_with_graceful_shutdown`.

# How to test or review this PR

Change the hyper unit test to use `serve_with_graceful_shutdown`, e.g.

```rust
App::default().serve_with_graceful_shutdown(&addr, async {
    tokio::signal::ctrl_c().await.unwrap()
}).await.unwrap();
```