### PR TITLE
fix cookie extraction when http/2 is used

### DIFF
--- a/mendes/Cargo.toml
+++ b/mendes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mendes"
-version = "0.3.1"
+version = "0.3.2"
 description = "Rust web toolkit for impatient perfectionists"
 documentation = "https://docs.rs/mendes"
 repository = "https://github.com/djc/mendes"


### PR DESCRIPTION
With http/2 the spec allows a single Cookie header for each cookie for better compression. The current code only checks the first cookie header and subsequent headers are not checked. This changes the behaviour. See tests.