### PR TITLE
Refactor hyper server creation

### DIFF
--- a/mendes/src/application.rs
+++ b/mendes/src/application.rs
@@ -1,8 +1,6 @@
 use std::borrow::Cow;
 #[cfg(feature = "with-http-body")]
 use std::error::Error as StdError;
-use std::future::Future;
-use std::net::SocketAddr;
 use std::str;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -686,17 +684,4 @@ impl From<&Error> for StatusCode {
             FileNotFound => StatusCode::NOT_FOUND,
         }
     }
-}
-
-/// Extension trait for serving an `Application` on the given `SocketAddr`
-#[async_trait]
-pub trait Server: Application {
-    type ServerError;
-
-    async fn serve(self, addr: &SocketAddr) -> Result<(), Self::ServerError>;
-    async fn serve_with_graceful_shutdown(
-        self,
-        addr: &SocketAddr,
-        signal: impl Future<Output = ()> + Send,
-    ) -> Result<(), Self::ServerError>;
 }


### PR DESCRIPTION
This changes the way to start a mendes `Application` server.

In some situations, you need to know the local address of a socket before starting the server (e.g. you need to hand in config parameters to the application that mention the port), or you want to modify TCP settings.

While this PR originally tried to extend the Server trait, after some feedback, it now exposes a `hyper::service::make_service_fn` equivalent implementation for `Application`.

Calling `Application::into_hyper_service()` allows you to pass the result to `hyper::server::Builder::serve()` (see docs, tests)
We should be able to switch out hyper against tower-service once hyper::Body is no longer part of hyper (hyper 1.x), reducing the footprint in the future.