### PR TITLE
Adjust mendes version to 0.5.1

### DIFF
--- a/mendes/Cargo.toml
+++ b/mendes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mendes"
-version = "0.6.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.63"
 description = "Rust web toolkit for impatient perfectionists"


### PR DESCRIPTION
The changes in #89 were actually semver-compatible, since they merely widen the blanket impl of IntoResponse for `Result`.

r? @valkum 