### PR TITLE
bump version to 0.9.4

### DIFF
--- a/mendes/Cargo.toml
+++ b/mendes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mendes"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 rust-version = "1.70"
 description = "Rust web toolkit for impatient perfectionists"


### PR DESCRIPTION
This bumps the version to 0.9.4

See https://github.com/djc/mendes/compare/76af39dc6907779e4bebb6b02cd141815df19390..main for changes since 0.9.3
<s>
The list of changes contains added implementations and a MSRV bump; thus I opted for a minor release.
</s>